### PR TITLE
infra-bin-releases: make build.sh idempotent (`mkdir -p go`)

### DIFF
--- a/infra-bin-releases/build.sh
+++ b/infra-bin-releases/build.sh
@@ -3,24 +3,32 @@ set -x
 set -e
 
 equo up && equo i dev-lang/go
-mkdir go
-export GOPATH=$PWD/go
-export PATH="$PATH:$GOPATH/bin"
-WORKDIR=$PWD
-VENDORDIR="github.com/MottainaiCI"
 
-mkdir -p go/src/${VENDORDIR}
+mkdir -p go
+export GOPATH="$PWD/go"
+export PATH="$PATH:$GOPATH/bin"
+WORKDIR="$PWD"
+VENDORDIR="github.com/MottainaiCI"
+mkdir -p "go/src/${VENDORDIR}"
+mkdir -p "${WORKDIR}/artefacts"
 
 for SUBPROJECT in "mottainai-server" "mottainai-cli" "mottainai-agent" "replicant"
 do
-  git clone https://${VENDORDIR}/${SUBPROJECT} go/src/${VENDORDIR}/${SUBPROJECT}
-  pushd go/src/${VENDORDIR}/${SUBPROJECT}
+  git clone "https://${VENDORDIR}/${SUBPROJECT}" "go/src/${VENDORDIR}/${SUBPROJECT}"
+  pushd "go/src/${VENDORDIR}/${SUBPROJECT}"
+
   [ -z "${PROJECT_BRANCH}" ] || {
-    git checkout ${PROJECT_BRANCH}
+    git checkout "${PROJECT_BRANCH}"
   }
+
   make deps
   make multiarch-build
-  for i in release/${SUBPROJECT}-* ; do arch=${i##*-} ; ln -s $(basename $i) release/${SUBPROJECT}-latest-linux-${arch}  ; done
-  mv release/* $WORKDIR/artefacts/
+
+  for i in release/${SUBPROJECT}-* ; do
+    arch="${i##*-}"
+    ln -sf "$(basename "$i")" "release/${SUBPROJECT}-latest-linux-${arch}"
+  done
+
+  mv release/* "${WORKDIR}/artefacts/"
   popd
 done


### PR DESCRIPTION
Change `mkdir go` to `mkdir -p go` in `infra-bin-releases/build.sh`.

The script runs under `set -e`. `mkdir go` (without `-p`) exits non-zero if `go/` already exists, which happens on any re-run or whenever the workspace isn't pristine, and `set -e` then aborts the entire build.

The very next `mkdir` in the same script (line 11, `mkdir -p go/src/${VENDORDIR}`) already uses `-p`, so this just makes the two consistent.